### PR TITLE
added proxy support

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,9 +9,19 @@ module.exports = function WebpackHotServer(compiler, options) {
     app.use(require('webpack-hot-middleware')(compiler))
   }
 
+  if (options.proxy) {
+    var proxy = require('express-http-proxy')
+    Object.keys(options.proxy).map(function (path) {
+  		app.use(path, proxy(options.proxy[path], {
+        forwardPath: function(req, res) {
+          return require('url').parse(req.url).path;
+        }
+      }));
+  	});
+  }
+
   app.use(express.static(options.contentBase))
 
   return app
 
 }
-

--- a/index.js
+++ b/index.js
@@ -12,12 +12,12 @@ module.exports = function WebpackHotServer(compiler, options) {
   if (options.proxy) {
     var proxy = require('express-http-proxy')
     Object.keys(options.proxy).map(function (path) {
-  		app.use(path, proxy(options.proxy[path], {
+      app.use(path, proxy(options.proxy[path], {
         forwardPath: function(req, res) {
-          return require('url').parse(req.url).path;
+          return require('url').parse(req.url).path
         }
-      }));
-  	});
+      }))
+    })
   }
 
   app.use(express.static(options.contentBase))

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "license": "ISC",
   "dependencies": {
     "express": "^4.13.3",
+    "express-http-proxy": "^0.6.0",
     "webpack-dev-middleware": "^1.2.0",
     "webpack-hot-middleware": "^2.0.0"
   }


### PR DESCRIPTION
Each key in the proxy object in the passed options will add a proxy mapping. e.g:

``` javascript
var options = {
   status: false
   hot: true,
   proxy: {
      "/externapi": "http://localhost:8080",
      "/internapi": "http://google.com"
    }
}
```
